### PR TITLE
Fixed small typo

### DIFF
--- a/f8-f9.org
+++ b/f8-f9.org
@@ -94,7 +94,7 @@ file_to_term(File) ->
 
 #+BEGIN_erlang
 consult(F) ->
-    {ok, [L]} = file:consult(F),
+    {ok, L} = file:consult(F),
     L.
 
 unconsult(File, Term) ->


### PR DESCRIPTION
The list that "file:consult(File)" returns cannot be matched into [L], it has to be just L.
